### PR TITLE
ENH: Workflow overhaul

### DIFF
--- a/nirodents/data/artsBrainExtraction_precise_T2w.json
+++ b/nirodents/data/artsBrainExtraction_precise_T2w.json
@@ -1,0 +1,61 @@
+{
+  "collapse_output_transforms": true,
+  "convergence_threshold": [1E-8, 1E-8, 1E-9],
+  "convergence_window_size": [10, 10, 15],
+  "dimension": 3,
+  "interpolation": "LanczosWindowedSinc",
+  "metric": [
+    "MI",
+    "MI",
+    ["CC", "CC"]
+  ],
+  "metric_weight": [
+    1,
+    1,
+    [0.5, 0.5]
+  ],
+  "number_of_iterations": [
+    [1000, 500, 250, 100],
+    [1000, 500, 250, 100],
+    [50, 10, 0]
+  ],
+  "output_transform_prefix": "anat_to_template",
+  "output_warped_image": true,
+  "radius_or_number_of_bins": [
+    32,
+    32,
+    [4, 4]
+  ],
+  "sampling_percentage": [
+    0.25,
+    0.25,
+    [1, 1]
+  ],
+  "sampling_strategy": [
+    "Regular",
+    "Regular",
+    ["None", "None"]
+  ],
+  "shrink_factors": [
+    [8, 4, 2, 1],
+    [8, 4, 2, 1],
+    [4, 2, 1]
+  ],
+  "sigma_units": ["vox", "vox", "vox"],
+  "smoothing_sigmas": [
+    [4, 2, 1, 0],
+    [4, 2, 1, 0],
+    [2, 1, 0]
+  ],
+  "transform_parameters": [
+    [0.1],
+    [0.1],
+    [0.1, 3.0, 0.0]
+  ],
+  "transforms": ["Rigid", "Affine", "SyN"],
+  "use_histogram_matching": true,
+  "verbose": true,
+  "winsorize_lower_quantile": 0.01,
+  "winsorize_upper_quantile": 0.975,
+  "write_composite_transform": false
+}

--- a/nirodents/data/artsBrainExtraction_testing_T2w.json
+++ b/nirodents/data/artsBrainExtraction_testing_T2w.json
@@ -1,0 +1,62 @@
+
+{
+  "collapse_output_transforms": true,
+  "convergence_threshold": [1E-8, 1E-8, 1E-9],
+  "convergence_window_size": [10, 10, 15],
+  "dimension": 3,
+  "interpolation": "LanczosWindowedSinc",
+  "metric": [
+    "MI",
+    "MI",
+    ["CC", "CC"]
+  ],
+  "metric_weight": [
+    1,
+    1,
+    [0.5, 0.5]
+  ],
+  "number_of_iterations": [
+    [100, 100, 50, 10],
+    [100, 100, 50, 10],
+    [5, 0]
+  ],
+  "output_transform_prefix": "anat_to_template",
+  "output_warped_image": true,
+  "radius_or_number_of_bins": [
+    32,
+    32,
+    [4, 4]
+  ],
+  "sampling_percentage": [
+    0.25,
+    0.25,
+    [1, 1]
+  ],
+  "sampling_strategy": [
+    "Regular",
+    "Regular",
+    ["None", "None"]
+  ],
+  "shrink_factors": [
+    [8, 4, 2, 1],
+    [8, 4, 2, 1],
+    [2, 1]
+  ],
+  "sigma_units": ["vox", "vox", "vox"],
+  "smoothing_sigmas": [
+    [4, 2, 1, 0],
+    [4, 2, 1, 0],
+    [1, 0]
+  ],
+  "transform_parameters": [
+    [0.1],
+    [0.1],
+    [0.1, 3.0, 0.0]
+  ],
+  "transforms": ["Rigid", "Affine", "SyN"],
+  "use_histogram_matching": true,
+  "verbose": true,
+  "winsorize_lower_quantile": 0.01,
+  "winsorize_upper_quantile": 0.975,
+  "write_composite_transform": false
+}

--- a/nirodents/utils/filtering.py
+++ b/nirodents/utils/filtering.py
@@ -1,0 +1,66 @@
+"""Signal processing filters."""
+
+
+def truncation(
+    in_file,
+    clip_max=99.9,
+    dtype='int16',
+    out_file=None,
+    out_max=1000,
+    out_min=0,
+    percentiles=(0.1, 95),
+):
+    """Truncate and clip the input image intensities."""
+    from pathlib import Path
+    import numpy as np
+    import nibabel as nb
+    from nipype.utils.filemanip import fname_presuffix
+    try:
+        info = np.iinfo(dtype)
+    except ValueError:
+        info = np.finfo(dtype)
+
+    img = nb.load(in_file)
+    hdr = img.header.copy()
+    hdr.set_data_dtype(dtype)
+
+    data = img.get_fdata()
+
+    out_min = max(out_min, info.min)
+    out_max = min(out_max, info.max)
+
+    a_min = np.percentile(data.reshape(-1), percentiles[0])
+    data -= a_min
+    a_max = np.percentile(data.reshape(-1), percentiles[1])
+    data *= out_max / a_max
+    data = np.clip(data, info.min, info.max)
+
+    if clip_max is not None:
+        data = np.clip(data, 0, np.percentile(data.reshape(-1), clip_max))
+
+    if out_file is None:
+        out_file = fname_presuffix(Path(in_file).name, suffix="_trunc")
+
+    out_file = str(Path(out_file).absolute())
+    img.__class__(
+        data.astype(dtype), img.affine, hdr
+    ).to_filename(out_file)
+    return out_file
+
+
+def gaussian_filter(in_file, sigma, out_file=None):
+    """Filter input image by convolving with a Gaussian kernel."""
+    from pathlib import Path
+    import nibabel as nb
+    from scipy.ndimage import gaussian_filter
+    from nipype.utils.filemanip import fname_presuffix
+
+    if out_file is None:
+        out_file = fname_presuffix(Path(in_file).name, suffix="_gauss")
+    out_file = str(Path(out_file).absolute())
+
+    img = nb.load(in_file)
+    img.__class__(
+        gaussian_filter(img.dataobj, sigma), img.affine, img.header
+    ).to_filename(out_file)
+    return out_file

--- a/nirodents/workflows/brainextraction.py
+++ b/nirodents/workflows/brainextraction.py
@@ -1,31 +1,36 @@
 # emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
 # vi: set ft=python sts=4 ts=4 sw=4 et:
 """Nipype translation of ANTs' workflows."""
-
+import numpy as np
 # general purpose
-from multiprocessing import cpu_count
 from pkg_resources import resource_filename as pkgr_fn
 
 # nipype
 from nipype.pipeline import engine as pe
 from nipype.interfaces import utility as niu
-from nipype.interfaces.ants import N4BiasFieldCorrection, Atropos
+from nipype.interfaces.ants import N4BiasFieldCorrection
 from nipype.interfaces.ants.utils import AI
-from nipype.interfaces.afni import MaskTool
-from nipype.interfaces.io import DataSink
 
 # niworkflows
 from niworkflows.interfaces.ants import ImageMath
 from niworkflows.interfaces.images import RegridToZooms
-from niworkflows.interfaces.nibabel import ApplyMask
+from niworkflows.interfaces.nibabel import ApplyMask, Binarize
 from niworkflows.interfaces.fixes import (
     FixHeaderRegistration as Registration,
     FixHeaderApplyTransforms as ApplyTransforms,
 )
+from niworkflows.interfaces.registration import (
+    SimpleBeforeAfterRPT as SimpleBeforeAfter
+)
 
 from templateflow.api import get as get_template
+from ..utils.filtering import (
+    gaussian_filter as _gauss_filter,
+    truncation as _trunc
+)
 
-LOWRES_ZOOMS = (0.4, 0.4, 0.4)
+LOWRES_ZOOMS = (0.42, 0.42, 0.42)
+HIRES_ZOOMS = (0.1, 0.1, 0.1)
 
 
 def init_rodent_brain_extraction_wf(
@@ -33,7 +38,7 @@ def init_rodent_brain_extraction_wf(
     atropos_refine=True,
     atropos_use_random_seed=True,
     bids_suffix="T2w",
-    bspline_fitting_distance=8,  # 4
+    bspline_fitting_distance=8,
     debug=False,
     final_normalization_quality="precise",
     in_template="WHS",
@@ -43,6 +48,7 @@ def init_rodent_brain_extraction_wf(
     omp_nthreads=None,
     template_spec=None,
     use_float=True,
+    interim_checkpoints=True,
 ):
     """
     Build an atlas-based brain extraction pipeline for rodent T1w and T2w MRI data.
@@ -53,121 +59,193 @@ def init_rodent_brain_extraction_wf(
         Run an extra step to refine the brain mask using a brain-tissue segmentation with Atropos.
 
     """
-
-    if omp_nthreads is None or omp_nthreads < 1:
-        omp_nthreads = cpu_count()
-
     inputnode = pe.Node(
         niu.IdentityInterface(fields=["in_files", "in_mask"]), name="inputnode"
     )
+    outputnode = pe.Node(
+        niu.IdentityInterface(fields=["out_corrected", "out_brain", "out_mask"]),
+        name="outputnode"
+    )
 
-    # Find images in templateFlow
+    # Find a suitable target template in TemplateFlow
     tpl_target_path = get_template(
         in_template,
-        resolution=debug + 1,
+        resolution=2,
         suffix="T2star" if bids_suffix == "T2w" else "T1w",
     )
-    tpl_regmask_path = get_template(
-        in_template, resolution=debug + 1, atlas=None, desc="brain", suffix="mask"
+    if not tpl_target_path:
+        raise RuntimeError(
+            f"An instance of template <tpl-{in_template}> with MR scheme '{bids_suffix}'"
+            " could not be found.")
+
+    tpl_brainmask_path = get_template(
+        in_template, resolution=2, atlas=None, desc="brain", suffix="probseg",
     )
-    if tpl_regmask_path:
-        inputnode.inputs.in_mask = str(tpl_regmask_path)
-    tpl_tissue_labels = get_template(
-        in_template, resolution=debug + 1, desc="cerebrum", suffix="dseg"
-    )
-    tpl_brain_mask = get_template(
-        in_template, resolution=debug + 1, desc="cerebrum", suffix="mask"
-    )
+    if not tpl_brainmask_path:
+        tpl_brainmask_path = get_template(
+            in_template, resolution=2, atlas=None, desc="brain", suffix="mask",
+        )
 
-    # resample template and target
-    res_tmpl = pe.Node(
-        RegridToZooms(in_file=tpl_target_path, zooms=LOWRES_ZOOMS), name="res_tmpl"
-    )
-
-    res_target = pe.Node(RegridToZooms(zooms=LOWRES_ZOOMS), name="res_target")
-    res_target2 = pe.Node(RegridToZooms(zooms=LOWRES_ZOOMS), name="res_target2")
-
-    dil_mask = pe.Node(
-        MaskTool(outputtype="NIFTI_GZ", dilate_inputs="2", fill_holes=True),
-        name="dil_mask",
-    )
-
-    # truncate target intensity for N4 correction
-    trunc_opts = {"T1w": "0.005 0.999 256", "T2w": "0.01 0.999 256"}
-    trunc = pe.MapNode(
-        ImageMath(operation="TruncateImageIntensity", op2=trunc_opts[bids_suffix]),
-        name="truncate_images",
-        iterfield=["op1"],
-    )
-
-    # Initial N4 correction
-    inu_n4 = pe.MapNode(
-        N4BiasFieldCorrection(
-            dimension=3,
-            save_bias=False,
-            copy_header=True,
-            n_iterations=[50] * 4,
-            convergence_threshold=1e-7,
-            shrink_factor=4,
-            bspline_fitting_distance=bspline_fitting_distance,
-        ),
-        n_procs=omp_nthreads,
-        name="inu_n4",
-        iterfield=["input_image"],
-    )
-
-    lap_tmpl = pe.Node(ImageMath(operation="Laplacian", op2="0.4"), name="lap_tmpl")
-    if tpl_target_path:
-        lap_tmpl.inputs.op1 = tpl_target_path
-    lap_target = pe.Node(ImageMath(operation="Laplacian", op2="0.4"), name="lap_target")
-
-    norm_lap_tmpl = pe.Node(ImageMath(operation="Normalize"), name="norm_lap_tmpl")
-    norm_lap_target = pe.Node(ImageMath(operation="Normalize"), name="norm_lap_target")
-
-    # Merge image nodes
-    mrg_target = pe.Node(niu.Merge(2), name="mrg_target")
-    mrg_tmpl = pe.Node(niu.Merge(2), name="mrg_tmpl")
-    # mrg_tmpl.inputs.in1 = tpl_target_path
-
-    # Create integration nodes to allow compatibility between pipelines
-    integrate_1 = pe.Node(niu.IdentityInterface(fields=["in_file"]), name="integrate_1")
-    integrate_2 = pe.Node(niu.IdentityInterface(fields=["in_file"]), name="integrate_2")
+    # Resample both target and template to a controlled, isotropic resolution
+    res_tmpl = pe.Node(RegridToZooms(zooms=HIRES_ZOOMS), name="res_tmpl")
+    res_target = pe.Node(RegridToZooms(zooms=HIRES_ZOOMS), name="res_target")
+    lowres_tmpl = pe.Node(RegridToZooms(zooms=LOWRES_ZOOMS), name="lowres_tmpl")
+    lowres_target = pe.Node(RegridToZooms(zooms=LOWRES_ZOOMS), name="lowres_target")
+    gauss_tmpl = pe.Node(niu.Function(function=_gauss_filter), name="gauss_tmpl")
+    gauss_tmpl.inputs.sigma = tuple(np.array(LOWRES_ZOOMS) * 8.0)
 
     # Initialize transforms with antsAI
     init_aff = pe.Node(
         AI(
-            metric=("Mattes", 32, "Regular", 0.5),  # 0.25
-            transform=("Rigid", 0.1),
-            search_factor=(2, 0.015),
+            metric=("Mattes", 32, "Regular", 1.0),
+            transform=("Affine", 0.1),
+            search_factor=(10, 0.08),
             principal_axes=False,
-            convergence=(10, 1e-6, 10),
-            search_grid=(1, (1, 2, 2)),
+            convergence=(40, 1e-6, 10),
+            search_grid=(25, (0, 0, 0)),
             verbose=True,
         ),
         name="init_aff",
         n_procs=omp_nthreads,
     )
 
-    # Initial warping of template mask to subject space
-    warp_mask_1 = pe.Node(
-        ApplyTransforms(interpolation="Linear", invert_transform_flags=True),
-        name="warp_mask_1",
+    # main workflow
+    wf = pe.Workflow(name)
+    # Create a buffer interface as a cache for the actual inputs to registration
+    buffernode = pe.Node(niu.IdentityInterface(
+        fields=["lowres_target", "hires_target"]), name="buffernode")
+
+    if bids_suffix.lower() == "t2w":
+        mask_tmpl = pe.Node(
+            ApplyMask(
+                in_file=_pop(tpl_target_path),
+                in_mask=_pop(tpl_brainmask_path),
+            ),
+            name="mask_tmpl",
+        )
+        # truncate target intensity for N4 correction
+        clip_target = pe.Node(
+            niu.Function(function=_trunc),
+            name="clip_target",
+        )
+        clip_tmpl = pe.Node(
+            niu.Function(function=_trunc),
+            name="clip_tmpl",
+        )
+        # INU correction of the target image
+        init_n4 = pe.Node(
+            N4BiasFieldCorrection(
+                dimension=3,
+                save_bias=False,
+                copy_header=True,
+                n_iterations=[50] * (4 - debug),
+                convergence_threshold=1e-7,
+                shrink_factor=4,
+                bspline_fitting_distance=bspline_fitting_distance,
+            ),
+            n_procs=omp_nthreads,
+            name="init_n4",
+        )
+        clip_inu = pe.Node(
+            niu.Function(function=_trunc),
+            name="clip_inu",
+        )
+        gauss_target = pe.Node(niu.Function(function=_gauss_filter), name="gauss_target")
+        gauss_target.inputs.sigma = tuple(np.array(LOWRES_ZOOMS) * 2.0)
+        wf.connect([
+            # truncation, resampling, and initial N4
+            (inputnode, res_target, [(("in_files", _pop), "in_file")]),
+            (mask_tmpl, clip_tmpl, [("out_file", "in_file")]),
+            (res_target, clip_target, [("out_file", "in_file")]),
+            (clip_tmpl, res_tmpl, [("out", "in_file")]),
+            (clip_target, init_n4, [("out", "input_image")]),
+            (init_n4, clip_inu, [("output_image", "in_file")]),
+            (clip_inu, gauss_target, [("out", "in_file")]),
+            (gauss_target, lowres_target, [("out", "in_file")]),
+            (lowres_target, buffernode, [("out_file", "lowres_target")]),
+            (clip_inu, buffernode, [("out", "hires_target")]),
+        ])
+    elif bids_suffix == "t1w":
+        wf.connect([
+            # resampling and laplacian; no truncation or N4
+            (inputnode, res_target, [("in_files", "in_file")]),
+            (res_target, buffernode, [("out_file", "lowres_target")]),
+        ])
+
+    wf.connect([
+        # ants AI inputs
+        (buffernode, init_aff, [("lowres_target", "moving_image")]),
+        (res_tmpl, gauss_tmpl, [("out_file", "in_file")]),
+        (gauss_tmpl, lowres_tmpl, [("out", "in_file")]),
+        (lowres_tmpl, init_aff, [("out_file", "fixed_image")]),
+    ])
+
+    # Graft a template registration-mask if present
+    tpl_regmask_path = get_template(
+        in_template, resolution=2, atlas=None, desc="BrainCerebellumExtraction", suffix="mask",
     )
+    if tpl_regmask_path:
+        lowres_mask = pe.Node(
+            ApplyTransforms(
+                input_image=_pop(tpl_regmask_path),
+                transforms="identity",
+                interpolation="MultiLabel",
+                float=True),
+            name="lowres_mask",
+            mem_gb=1
+        )
+
+        hires_mask = pe.Node(
+            ApplyTransforms(
+                input_image=_pop(tpl_regmask_path),
+                transforms="identity",
+                interpolation="NearestNeighbor",
+                float=True),
+            name="hires_mask",
+            mem_gb=1
+        )
+        wf.connect([
+            (lowres_tmpl, lowres_mask, [("out_file", "reference_image")]),
+            (lowres_mask, init_aff, [("output_image", "fixed_image_mask")]),
+            (res_tmpl, hires_mask, [("out_file", "reference_image")]),
+        ])
+
+    # Spatial normalization step
+    lap_tmpl = pe.Node(ImageMath(operation="Laplacian", op2="0.4 1.0"), name="lap_tmpl")
+    lap_target = pe.Node(ImageMath(operation="Laplacian", op2="0.4 1.0"), name="lap_target")
+
+    # Merge image nodes
+    mrg_target = pe.Node(niu.Merge(2), name="mrg_target")
+    mrg_tmpl = pe.Node(niu.Merge(2), name="mrg_tmpl")
+
+    # norm_lap_tmpl = pe.Node(ImageMath(operation="Normalize"), name="norm_lap_tmpl")
+    # norm_lap_target = pe.Node(ImageMath(operation="Normalize"), name="norm_lap_target")
 
     # Set up initial spatial normalization
-    init_settings_file = (
-        f"data/brainextraction_{init_normalization_quality}_{bids_suffix}.json"
-    )
-    init_norm = pe.Node(
-        Registration(from_file=pkgr_fn("nirodents", init_settings_file)),
-        name="init_norm",
+    ants_params = "testing" if debug else "precise"
+    norm = pe.Node(
+        Registration(from_file=pkgr_fn(
+            "nirodents",
+            f"data/artsBrainExtraction_{ants_params}_{bids_suffix}.json")
+        ),
+        name="norm",
         n_procs=omp_nthreads,
         mem_gb=mem_gb,
     )
-    init_norm.inputs.float = use_float
+    norm.inputs.float = use_float
+
+    map_brainmask = pe.Node(
+        ApplyTransforms(interpolation="Gaussian", float=True),
+        name="map_brainmask",
+        mem_gb=1
+    )
+    map_brainmask.inputs.input_image = str(tpl_brainmask_path)
+
+    thr_brainmask = pe.Node(Binarize(thresh_low=0.5),
+                            name="thr_brainmask")
 
     # Refine INU correction
-    inu_n4_final = pe.MapNode(
+    final_n4 = pe.Node(
         N4BiasFieldCorrection(
             dimension=3,
             save_bias=True,
@@ -179,181 +257,85 @@ def init_rodent_brain_extraction_wf(
             shrink_factor=4,
         ),
         n_procs=omp_nthreads,
-        name="inu_n4_final",
-        iterfield=["input_image"],
+        name="final_n4",
     )
+    final_mask = pe.Node(ApplyMask(), name="final_mask")
 
-    split_init_transforms = pe.Node(
-        niu.Split(splits=[1, 1]), name="split_init_transforms"
-    )
-    mrg_init_transforms = pe.Node(niu.Merge(2), name="mrg_init_transforms")
-
-    # Use more precise transforms to warp mask to subject space
-    warp_mask_2 = pe.Node(
-        ApplyTransforms(interpolation="Linear", invert_transform_flags=[False, True]),
-        name="warp_mask_2",
-    )
-
-    # morphological closing of warped mask
-    close_mask = pe.Node(
-        MaskTool(outputtype="NIFTI_GZ", dilate_inputs="5 -5", fill_holes=True),
-        name="close_mask",
-    )
-
-    # Use subject-space mask to skull-strip subject
-    skullstrip_tar = pe.Node(ApplyMask(), name="skullstrip_tar")
-    skullstrip_tpl = pe.Node(ApplyMask(), name="skullstrip_tpl")
-    if tpl_target_path:
-        skullstrip_tpl.inputs.in_file = tpl_target_path
-
-    # Normalise skull-stripped image to brain template
-    final_settings_file = (
-        f"data/brainextraction_{final_normalization_quality}_{bids_suffix}.json"
-    )
-    refine_norm = pe.Node(
-        Registration(from_file=pkgr_fn("nirodents", final_settings_file)),
-        name="refine_norm",
-        n_procs=omp_nthreads,
-        mem_gb=mem_gb,
-    )
-    refine_norm.inputs.float = use_float
-
-    split_final_transforms = pe.Node(
-        niu.Split(splits=[1, 1]), name="split_final_transforms"
-    )
-    mrg_final_transforms = pe.Node(niu.Merge(2), name="mrg_final_transforms")
-
-    warp_mask_out = pe.Node(
-        ApplyTransforms(interpolation="Linear", invert_transform_flags=[False, True]),
-        name="warp_mask_out",
-    )
-    if tpl_brain_mask:
-        warp_mask_out.inputs.input_image = tpl_brain_mask
-    else:
-        warp_mask_out.inputs.input_image = tpl_regmask_path
-
-    warp_seg_labels = pe.Node(
-        ApplyTransforms(interpolation="Linear", invert_transform_flags=[False, True]),
-        name="warp_seg_labels",
-    )
-    if tpl_tissue_labels:
-        warp_seg_labels.inputs.input_image = tpl_tissue_labels
-
-    segment = pe.Node(
-        Atropos(
-            dimension=3,
-            initialization="PriorLabelImage",
-            number_of_tissue_classes=2,
-            prior_weighting=0.03,
-            posterior_formulation="Aristotle",
-            n_iterations=50,
-            convergence_threshold=0.0001,
-            mrf_smoothing_factor=0.015,
-            mrf_radius=[1, 1, 1],
-        ),
-        name="segment",
-    )
-
-    sinker = pe.Node(DataSink(), name="sinker")
-
-    # workflow definitions
-    # target image specific workflows
-    tar_prep = pe.Workflow("tar_prep")
-    if bids_suffix.lower() == "t2w":
-        tar_prep.connect([
-            # truncation, resampling, and initial N4
-            (inputnode, trunc, [("in_files", "op1")]),
-            (trunc, res_target, [(("output_image", _pop), "in_file")]),
-            (res_target, inu_n4, [("out_file", "input_image")]),
-            (inu_n4, integrate_1, [(("output_image", _pop), "in_file")]),
-            # masked N4 correction
-            (trunc, inu_n4_final, [(("output_image", _pop), "input_image")]),
-            (inu_n4_final, integrate_2, [(("output_image", _pop), "in_file")]),
-            # merge laplacian and original images
-            (inu_n4_final, lap_target, [(("output_image", _pop), "op1")]),
-            (lap_target, norm_lap_target, [("output_image", "op1")]),
-            (norm_lap_target, mrg_target, [("output_image", "in2")]),
-            (inu_n4_final, res_target2, [(("output_image", _pop), "in_file")]),
-            (res_target2, mrg_target, [("out_file", "in1")]),
-        ])
-    elif bids_suffix == "t1w":
-        tar_prep.connect([
-            # resampling and laplacian; no truncation or N4
-            (inputnode, res_target, [("in_files", "in_file")]),
-            (inputnode, lap_target, [("in_files", "op1")]),
-            (lap_target, norm_lap_target, [("output_image", "op1")]),
-            (norm_lap_target, mrg_target, [("output_image", "in2")]),
-            (res_target, mrg_target, [("out_file", "in1")]),
-            (res_target, integrate_1, [("out_file", "in_file")]),
-            (inputnode, integrate_2, [("in_files", "in_file")]),
-        ])
-
-    # main workflow
-    wf = pe.Workflow(name)
     wf.connect([
-        # template prep: dilation of input mask, resampling template, laplacian creation
-        (inputnode, dil_mask, [("in_mask", "in_file")]),
+        (inputnode, map_brainmask, [(("in_files", _pop), "reference_image")]),
+        (inputnode, final_n4, [(("in_files", _pop), "input_image")]),
+        # merge laplacian and original images
+        (buffernode, lap_target, [("hires_target", "op1")]),
+        (buffernode, mrg_target, [("hires_target", "in1")]),
+        (lap_target, mrg_target, [("output_image", "in2")]),
+        # Template massaging
+        (res_tmpl, lap_tmpl, [("out_file", "op1")]),
         (res_tmpl, mrg_tmpl, [("out_file", "in1")]),
-        (lap_tmpl, norm_lap_tmpl, [("output_image", "op1")]),
-        (norm_lap_tmpl, mrg_tmpl, [("output_image", "in2")]),
-        # ants AI inputs
-        (tar_prep, init_aff, [("integrate_1.in_file", "moving_image")]),
-        (dil_mask, init_aff, [("out_file", "fixed_image_mask")]),
-        (res_tmpl, init_aff, [("out_file", "fixed_image")]),
-        # warp mask to individual space
-        (dil_mask, warp_mask_1, [("out_file", "input_image")]),
-        (init_aff, warp_mask_1, [("output_transform", "transforms")]),
-        (inputnode, warp_mask_1, [("in_files", "reference_image")]),
-        # normalisation inputs
-        (init_aff, init_norm, [("output_transform", "initial_moving_transform")]),
-        (warp_mask_1, init_norm, [("output_image", "moving_image_masks")]),
-        (dil_mask, init_norm, [("out_file", "fixed_image_masks")]),
-        (mrg_tmpl, init_norm, [("out", "fixed_image")]),
-        (tar_prep, init_norm, [("mrg_target.out", "moving_image")]),
-        # organise initial normalisation transforms for warps
-        (init_norm, split_init_transforms, [("reverse_transforms", "inlist")]),
-        (split_init_transforms, mrg_init_transforms, [("out2", "in1")]),
-        (split_init_transforms, mrg_init_transforms, [("out1", "in2")]),
-        # warp mask with initial normalisation transforms
-        (tar_prep, warp_mask_2, [("integrate_2.in_file", "reference_image")]),
-        (dil_mask, warp_mask_2, [("out_file", "input_image")]),
-        (mrg_init_transforms, warp_mask_2, [("out", "transforms")]),
-        (warp_mask_2, close_mask, [("output_image", "in_file")]),
-        # mask brains for refined normalisation
-        (tar_prep, skullstrip_tar, [("integrate_2.in_file", "in_file")]),
-        (close_mask, skullstrip_tar, [("out_file", "in_mask")]),
-        (inputnode, skullstrip_tpl, [("in_mask", "in_mask")]),
-        # refined normalisation
-        (skullstrip_tpl, refine_norm, [("out_file", "fixed_image")]),
-        (skullstrip_tar, refine_norm, [("out_file", "moving_image")]),
-        # organise refined normalisation transforms for warps
-        (refine_norm, split_final_transforms, [("reverse_transforms", "inlist")]),
-        (split_final_transforms, mrg_final_transforms, [("out2", "in1")]),
-        (split_final_transforms, mrg_final_transforms, [("out1", "in2")]),
-        # warp mask to subject space and write out
-        (mrg_final_transforms, warp_mask_out, [("out", "transforms")]),
-        (skullstrip_tar, warp_mask_out, [("out_file", "reference_image")]),
-        (warp_mask_out, sinker, [("output_image", "derivatives.@out_mask")]),
+        (lap_tmpl, mrg_tmpl, [("output_image", "in2")]),
+        # spatial normalization
+        (init_aff, norm, [("output_transform", "initial_moving_transform")]),
+        (mrg_target, norm, [("out", "moving_image")]),
+        (mrg_tmpl, norm, [("out", "fixed_image")]),
+        (norm, map_brainmask, [
+            ("reverse_transforms", "transforms"),
+            ("reverse_invert_flags", "invert_transform_flags")]),
+        (map_brainmask, thr_brainmask, [("output_image", "in_file")]),
+        # take a second pass of N4
+        (map_brainmask, final_n4, [("output_image", "weight_image")]),
+        (final_n4, final_mask, [("output_image", "in_file")]),
+        (thr_brainmask, final_mask, [("out_file", "in_mask")]),
+        (final_n4, outputnode, [("output_image", "out_corrected")]),
+        (thr_brainmask, outputnode, [("out_file", "out_mask")]),
+        (final_mask, outputnode, [("out_file", "out_brain")]),
     ])
-    # add second target prep stage if necessary
-    if bids_suffix.lower() == "t2w":
-        wf.connect(
-            [(warp_mask_1, tar_prep, [("output_image", "inu_n4_final.weight_image")])]
-        )
 
-    # add segmentation if necessary
-    if atropos_model:
-        wf.connect(
-            [
-                # Warp labels to subject-space
-                (mrg_final_transforms, warp_seg_labels, [("out", "transforms")]),
-                (skullstrip_tar, warp_seg_labels, [("out_file", "reference_image")]),
-                # Segmentation
-                (skullstrip_tar, segment, [("out_file", "intensity_images")]),
-                (warp_seg_labels, segment, [("output_image", "prior_image")]),
-                (warp_mask_out, segment, [("output_image", "mask_image")]),
-            ]
+    if tpl_regmask_path:
+        wf.connect([
+            (hires_mask, norm, [
+                ("output_image", "fixed_image_masks")]),
+        ])
+
+    if interim_checkpoints:
+        init_apply = pe.Node(
+            ApplyTransforms(
+                interpolation="BSpline",
+                float=True),
+            name="init_apply",
+            mem_gb=1
         )
+        init_report = pe.Node(SimpleBeforeAfter(
+            before_label="tpl-WHS",
+            after_label="target"),
+            name="init_report"
+        )
+        final_apply = pe.Node(
+            ApplyTransforms(
+                interpolation="BSpline",
+                float=True),
+            name="final_apply",
+            mem_gb=1
+        )
+        final_report = pe.Node(SimpleBeforeAfter(
+            before_label="tpl-WHS",
+            after_label="target"),
+            name="final_report"
+        )
+        wf.connect([
+            (buffernode, init_apply, [("lowres_target", "input_image")]),
+            (res_tmpl, init_apply, [("out_file", "reference_image")]),
+            (init_aff, init_apply, [("output_transform", "transforms")]),
+            (init_apply, init_report, [("output_image", "after")]),
+            (res_tmpl, init_report, [("out_file", "before")]),
+
+            (inputnode, final_apply, [(("in_files", _pop), "reference_image")]),
+            (res_tmpl, final_apply, [("out_file", "input_image")]),
+            (norm, final_apply, [
+                ("reverse_transforms", "transforms"),
+                ("reverse_invert_flags", "invert_transform_flags")]),
+            (final_apply, final_report, [("output_image", "before")]),
+            (outputnode, final_report, [("out_corrected", "after"),
+                                        ("out_mask", "wm_seg")]),
+        ])
 
     return wf
 

--- a/nirodents/workflows/brainextraction.py
+++ b/nirodents/workflows/brainextraction.py
@@ -211,8 +211,8 @@ def init_rodent_brain_extraction_wf(
         ])
 
     # Spatial normalization step
-    lap_tmpl = pe.Node(ImageMath(operation="Laplacian", op2="0.4 1.0"), name="lap_tmpl")
-    lap_target = pe.Node(ImageMath(operation="Laplacian", op2="0.4 1.0"), name="lap_target")
+    lap_tmpl = pe.Node(ImageMath(operation="Laplacian", op2="0.4 1"), name="lap_tmpl")
+    lap_target = pe.Node(ImageMath(operation="Laplacian", op2="0.4 1"), name="lap_target")
 
     # Merge image nodes
     mrg_target = pe.Node(niu.Merge(2), name="mrg_target")


### PR DESCRIPTION
The workflow had deviated quite substantially from the original for many reasons. I thought taking some steps backs and revising the basis would help us find a way.

The central change is the addition of Gaussian smoothing, in coordination with a more careful massaging of the resolution and intensity distribution of the inputs.

The resolution of the template is way too high, two versions of the data are generated with isotropic resolutions.

`antsAI` is back to a wider range of search, which is to account for datasets with weird positioning of the rat. With the much smoother inputs, now the Mattes metric is not as noisy and seems to converge to pretty decent results reliably (on this one dataset).

I have also updated templateflow with two resources that will be of interest (and currently in use by the pipeline). Only at resolution 2 (there's no point in doing it with res-1).

First, a registration mask, by heavily dilating the original brain mask. Second, a probabilistic brain mask to allow better brain extraction. Both additions just follow suit with the original `antsBrainExtraction` script.