### PR TITLE
PIN: niworkflows 1.4.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     attrs
     nibabel >= 3.0.1
     nipype ~= 1.5.1
-    niworkflows >= 1.4.0rc5
+    niworkflows ~= 1.4.0
     templateflow ~= 0.7.1
 
 test_requires =


### PR DESCRIPTION
Pinning Niworkflows release 1.4.x for compatibility for fmriprep rodents (poldracklab/fmriprep-rodents#36)