### PR TITLE
pin: bump niworkflows to 1.5.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     attrs
     nibabel >= 3.0.1
     nipype ~= 1.5.1
-    niworkflows ~= 1.5.0
+    niworkflows ~= 1.5.2
     templateflow ~= 0.7.1
 
 test_requires =

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ install_requires =
     attrs
     nibabel >= 3.0.1
     nipype ~= 1.5.1
-    niworkflows ~= 1.4.0
+    niworkflows ~= 1.5.0
     templateflow ~= 0.7.1
 
 test_requires =


### PR DESCRIPTION
For compatibility with nipreps/mriqc, this will bump niworkflows to 1.5.x release