### PR TITLE
fix: typo in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ setup_requires =
     setuptools_scm >= 6.2
     wheel
 
-iinstall_requires =
+install_requires =
     attrs
     networkx
     nibabel >= 3.0.1


### PR DESCRIPTION
extra `i` in `iinstall_requires` was causing pip installation to miss dependencies, including `niworkflows`.

Should fix #64 